### PR TITLE
Corrected value of Avogadro's number

### DIFF
--- a/apps/i18n.cpp
+++ b/apps/i18n.cpp
@@ -447,7 +447,7 @@ const char * universalMessages[478] {
   "confidence(f,n)",
 
   // Chemistry constants
-  "8.022*10^23",
+  "6.02214076*10^23",
   "1.008",
   "4.0026022",
   "6.94",


### PR DESCRIPTION
The first digit is a 6 rather than an 8. The entire precision can be included because it is [defined to be](https://www.bipm.org/utils/common/pdf/CGPM-2018/26th-CGPM-Resolutions.pdf) exactly 6.02214076×10^23 mol^-1 by the CGPM.